### PR TITLE
修复数值类型条件分支bug

### DIFF
--- a/antflowcore/constant/enums/JudgeOperatorEnum.cs
+++ b/antflowcore/constant/enums/JudgeOperatorEnum.cs
@@ -47,7 +47,7 @@ public class JudgeOperatorEnum
 
     private static JudgeOperatorEnum[] AllValues()
     {
-        return new[] { GTE, GT, LTE, LT, EQ };
+        return new[] { GTE, GT, LTE, LT, EQ, GT1LT2, GTE1LT2, GET1LE2, GTE1LTE2 };
     }
     public static List<int> BinaryOperator()
     {

--- a/antflowcore/util/BpmnConfNodePropertyConverter.cs
+++ b/antflowcore/util/BpmnConfNodePropertyConverter.cs
@@ -188,7 +188,7 @@ public class BpmnConfNodePropertyConverter
                     else
                     {
                         Object valueOrWrapper = null;
-                        Object actualValue = null;
+                        Object actualValue = zdy1;
                         Object zdy2Value = null;
                         if (!string.IsNullOrEmpty(zdy2))
                         {


### PR DESCRIPTION
1.修复数值类型分支条件，非【介于两数之间】条件 保存数据异常并且不能编辑预览问题
2.修复数值类型分支条件，【介于两数之间】条件 不能保存问题